### PR TITLE
Fix python 3.5 problems

### DIFF
--- a/Python_package/prg/prg.py
+++ b/Python_package/prg/prg.py
@@ -133,9 +133,9 @@ def _create_crossing_points(points, n_pos, n_neg):
         else:
             alpha = 0.5
 
-	with warnings.catch_warnings():
-	  warnings.simplefilter("ignore")
-          new_point = point_2 + alpha*delta
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            new_point = point_2 + alpha*delta
 
         new_prec_gain = precision_gain(new_point[key_indices_1['TP']], new_point[key_indices_1['FN']],
                                        new_point[key_indices_1['FP']], new_point[key_indices_1['TN']])
@@ -160,9 +160,9 @@ def _create_crossing_points(points, n_pos, n_neg):
         else:
             alpha = (n_neg / n_pos * points['TP'][i-1] - points['FP'][i-1]) / delta[key_indices_1['FP']]
 
-	with warnings.catch_warnings():
-	  warnings.simplefilter("ignore")
-          new_point = point_2 + alpha*delta
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            new_point = point_2 + alpha*delta
 
         new_rec_gain = recall_gain(new_point[key_indices_1['TP']], new_point[key_indices_1['FN']],
                                    new_point[key_indices_1['FP']], new_point[key_indices_1['TN']])
@@ -180,7 +180,7 @@ def _create_crossing_points(points, n_pos, n_neg):
 
 def create_prg_curve(labels, pos_scores, neg_scores=[]):
     """Precision-Recall-Gain curve
-    
+
     This function creates the Precision-Recall-Gain curve from the vector of labels and vector of scores where higher score indicates a higher probability to be positive. More information on Precision-Recall-Gain curves and how to cite this work is available at http://www.cs.bris.ac.uk/~flach/PRGcurves/.
     """
     create_crossing_points = True # do it always because calc_auprg otherwise gives the wrong result
@@ -207,14 +207,14 @@ def create_prg_curve(labels, pos_scores, neg_scores=[]):
     if create_crossing_points == True:
         points = _create_crossing_points(points, n_pos, n_neg)
     else:
-       points['pos_score'] = points['pos_score'][1:]
-       points['neg_score'] = points['neg_score'][1:]
-       points['TP'] = points['TP'][1:]
-       points['FP'] = points['FP'][1:]
-       points['FN'] = points['FN'][1:]
-       points['TN'] = points['TN'][1:]
-       points['precision_gain'] = points['precision_gain'][1:]
-       points['recall_gain'] = points['recall_gain'][1:]
+        points['pos_score'] = points['pos_score'][1:]
+        points['neg_score'] = points['neg_score'][1:]
+        points['TP'] = points['TP'][1:]
+        points['FP'] = points['FP'][1:]
+        points['FN'] = points['FN'][1:]
+        points['TN'] = points['TN'][1:]
+        points['precision_gain'] = points['precision_gain'][1:]
+        points['recall_gain'] = points['recall_gain'][1:]
     with np.errstate(invalid='ignore'):
         points['in_unit_square'] = np.logical_and(points['recall_gain'] >= 0,
                                               points['precision_gain'] >= 0)
@@ -240,7 +240,7 @@ def calc_auprg(prg_curve):
     return(area)
 
 
-# from 
+# from
 def convex_hull(points):
     """Computes the convex hull of a set of 2D points.
 

--- a/Python_package/prg/prg.py
+++ b/Python_package/prg/prg.py
@@ -181,7 +181,11 @@ def _create_crossing_points(points, n_pos, n_neg):
 def create_prg_curve(labels, pos_scores, neg_scores=[]):
     """Precision-Recall-Gain curve
 
-    This function creates the Precision-Recall-Gain curve from the vector of labels and vector of scores where higher score indicates a higher probability to be positive. More information on Precision-Recall-Gain curves and how to cite this work is available at http://www.cs.bris.ac.uk/~flach/PRGcurves/.
+    This function creates the Precision-Recall-Gain curve from the vector of
+    labels and vector of scores where higher score indicates a higher
+    probability to be positive. More information on Precision-Recall-Gain
+    curves and how to cite this work is available at
+    http://www.cs.bris.ac.uk/~flach/PRGcurves/.
     """
     create_crossing_points = True # do it always because calc_auprg otherwise gives the wrong result
     if np.alen(neg_scores) == 0:
@@ -276,19 +280,27 @@ def convex_hull(points):
     return upper
 
 
-#' Plot the Precision-Recall-Gain curve
-#'
-#' This function plots the Precision-Recall-Gain curve resulting from the function create_prg_curve using ggplot. More information on Precision-Recall-Gain curves and how to cite this work is available at http://www.cs.bris.ac.uk/~flach/PRGcurves/.
-#' @param prg_curve the data structure resulting from the function create_prg_curve
-#' @param show_convex_hull whether to show the convex hull (default: TRUE)
-#' @param show_f_calibrated_scores whether to show the F-calibrated scores (default:TRUE)
-#' @return the ggplot object which can be plotted using print()
-#' @details This function plots the Precision-Recall-Gain curve, indicating for each point whether it is a crossing-point or not (see help on create_prg_curve). By default, only the part of the curve within the unit square [0,1]x[0,1] is plotted.
-#' @examples
-#' labels = c(1,1,1,0,1,1,1,1,1,1,0,1,1,1,0,1,0,0,1,0,0,0,1,0,1)
-#' scores = (25:1)/25
-#' plot_prg(create_prg_curve(labels,scores))
 def plot_prg(prg_curve,show_convex_hull=True,show_f_calibrated_scores=False):
+    """Plot the Precision-Recall-Gain curve
+
+    This function plots the Precision-Recall-Gain curve resulting from the
+    function create_prg_curve using ggplot. More information on
+    Precision-Recall-Gain curves and how to cite this work is available at
+    http://www.cs.bris.ac.uk/~flach/PRGcurves/.
+
+    @param prg_curve the data structure resulting from the function create_prg_curve
+    @param show_convex_hull whether to show the convex hull (default: TRUE)
+    @param show_f_calibrated_scores whether to show the F-calibrated scores (default:TRUE)
+    @return the ggplot object which can be plotted using print()
+    @details This function plots the Precision-Recall-Gain curve, indicating
+        for each point whether it is a crossing-point or not (see help on
+        create_prg_curve). By default, only the part of the curve
+        within the unit square [0,1]x[0,1] is plotted.
+    @examples
+        labels = c(1,1,1,0,1,1,1,1,1,1,0,1,1,1,0,1,0,0,1,0,0,0,1,0,1)
+        scores = (25:1)/25
+        plot_prg(create_prg_curve(labels,scores))
+    """
     pg = prg_curve['precision_gain']
     rg = prg_curve['recall_gain']
 
@@ -331,6 +343,7 @@ def plot_prg(prg_curve,show_convex_hull=True,show_f_calibrated_scores=False):
     if show_f_calibrated_scores:
         raise Exception("Show calibrated scores not implemented yet")
     plt.show()
+    return fig
 
 
 def plot_pr(prg_curve):

--- a/Python_package/prg/prg.py
+++ b/Python_package/prg/prg.py
@@ -371,6 +371,7 @@ def plot_pr(prg_curve):
     plt.ylabel('Precision')
 
     plt.show()
+    return fig
 
 
 def test():


### PR DESCRIPTION
I had problems using the python package with python 3.5. I used autopep8 to fix the spaces/indents and now it works. I also found it more useful to return the figures from the plot routines. As an aside I didn't see how to raise an issue on github. Have you disabled this for this repository? And of course thanks for the code, it is very helpful.
